### PR TITLE
Http support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python-dev \
   ntpdate \
   ca-certificates \
-  tftpd-hpa \
   nfs-kernel-server \
   nfs-common \
   netbase \
   udhcpd 
 
 RUN mkdir -p /srv/nfs
+RUN mkdir -p /srv/http
 
 VOLUME /srv/nfs
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,32 @@ password: root
 
 ## Robot Framework
 
-Some automation of above process has been prepared. Relevant source code can be found [here](https://github.com/pcengines/apu-test-suite)
+Some automation of above process has been prepared. Relevant source code can be
+found [here](https://github.com/pcengines/apu-test-suite)
 
+## Chainloading over HTTP
+
+In some situation it may happen that TFTP server may be unreliable. There are
+known network configurations where routers filter tftp traffic. Simple
+workaround for that can be, instead of using above mentioned tftp server, try
+to use HTTP.
+
+Below example show how to netboot Debian installed with
+`NFS_SRV_IP=<host-pc-ip> ./init.sh` command.
+
+Go to `pxe-server` directory and run HTTP server:
+
+```
+python3 -m http.server
+```
+
+Boot to iPXE and type:
+
+```
+iPXE> ifconf net0
+iPXE> dhcp net0
+iPXE> chain http://${next-server}:8000/debian-netboot.ipxe
+```
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -28,41 +28,41 @@ APU2 development and testing
 ### Setting up docker container
 
 In order to set up isolated environment for pxe-server with nfs-server and
-tftp-boot, just run:
+http-boot, just run:
 
 ```
 ./start.sh
 ```
 
-This script builds a container and runs it with correct configuration of tftpd
-and nfs-kernel-server.
+This script builds a container and runs it with correct configuration
+nfs-kernel-server.
 
 `run.sh` is a script that runs at container startup, do not use it on Your host
 PC.
 
-### Booting iPXE on recent firmware
+## Chainloading over HTTP
 
-This instruction assume you do not provide information about TFTP server over
-DHCP.
+In some situation it may happen that TFTP server may be unreliable. There are
+known network configurations where routers filter tftp traffic. Because of that
+we decided to switch over to HTTP.
 
 Boot to iPXE and type:
 
 ```
 iPXE> ifconf net0
 iPXE> dhcp net0
-iPXE> set filename pxelinux.0
-iPXE> set next-server <tftpboot-server-ip>
-iPXE> chain tftp://${next-server}/${filename}
+iPXE> chain http://${next-server}:8000/menu.ipxe
 ```
 
 ### Select options
 
 Currently supported options are:
 
-1. `Debian-netboot` - it is a Debian Stretch rootfs served over nfs with custom
+1. `Debian stable netboot` - it is a Debian Stretch rootfs served over nfs with custom
 kernel
-2. `Voyage-netinst` - a Voyage Linux network installation image
-3. Debian `Install` - runs a Debian i386 network installation
+2. `Voyage netinst` - a Voyage Linux network installation image
+3. `Debian stable netinst` - runs a Debian stable amd64 network installation from external repository
+4. `Debian testing netinst` - runs a Debian testing amd64 network installation from external repository
 
 The credentials for Debian Stretch are as follows:
 login: root
@@ -73,29 +73,6 @@ password: root
 Some automation of above process has been prepared. Relevant source code can be
 found [here](https://github.com/pcengines/apu-test-suite)
 
-## Chainloading over HTTP
-
-In some situation it may happen that TFTP server may be unreliable. There are
-known network configurations where routers filter tftp traffic. Simple
-workaround for that can be, instead of using above mentioned tftp server, try
-to use HTTP.
-
-Below example show how to netboot Debian installed with
-`NFS_SRV_IP=<host-pc-ip> ./init.sh` command.
-
-Go to `pxe-server` directory and run HTTP server:
-
-```
-python3 -m http.server
-```
-
-Boot to iPXE and type:
-
-```
-iPXE> ifconf net0
-iPXE> dhcp net0
-iPXE> chain http://${next-server}:8000/debian-netboot.ipxe
-```
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ proper directories.
 > `init.sh` script uses our netboot repository by default. It is the repository it
 > should be paired with.
 
+Please note that `init.sh` also download prepared Debian boot images. In root
+directory of those images you can find `CHANGELOG` document which briefly
+describe modifications.
+
 APU2 development and testing
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ Boot to iPXE and type:
 ```
 iPXE> ifconf net0
 iPXE> dhcp net0
-iPXE> chain http://${next-server}:8000/menu.ipxe
+iPXE> chain http://<http-server-ip>:8000/menu.ipxe
 ```
+
+Of course please replace `<http-server-ip>` with address provided during
+initialization (`NFS_SRV_IP`).
 
 ### Select options
 
@@ -68,9 +71,17 @@ kernel
 3. `Debian stable netinst` - runs a Debian stable amd64 network installation from external repository
 4. `Debian testing netinst` - runs a Debian testing amd64 network installation from external repository
 
-The credentials for Debian Stretch are as follows:
+The credentials for Debian stable netboot are as follows:
 login: root
-password: root
+password: debian
+
+Those credentials are visible during boot:
+
+```
+Debian GNU/Linux 9 apu2 ttyS0 [root:debian]
+
+apu2 login: 
+```
 
 ## Robot Framework
 

--- a/init.sh
+++ b/init.sh
@@ -27,7 +27,7 @@ else
   exit 1
 fi
 
-git clone git@github.com:3mdeb/netboot.git
+git clone https://github.com/3mdeb/netboot.git
 
 cd netboot
 

--- a/init.sh
+++ b/init.sh
@@ -31,7 +31,7 @@ git clone https://github.com/3mdeb/netboot.git
 
 cd netboot
 
-sed -i "s/replace_with_ip/$NFS_SRV_IP/"  ./menu.ipxe
+sed -i "s/replace_with_ip/$NFS_SRV_IP/g"  ./menu.ipxe
 
 wget https://cloud.3mdeb.com/index.php/s/pHIz1Ir9m68Bjq3/download -O kernels.tar.gz
 

--- a/init.sh
+++ b/init.sh
@@ -31,25 +31,21 @@ git clone git@github.com:3mdeb/netboot.git
 
 cd netboot
 
-sed -i "s/192.168.0.109/$NFS_SRV_IP/"  ./debian-installer/i386/boot-screens/menu.cfg
- 
-wget http://ftp.debian.org/debian/dists/wheezy/main/installer-i386/current/images/netboot/netboot.tar.gz
-
-tar -xzvf netboot.tar.gz -C . --skip-old-files && rm  netboot.tar.gz
+sed -i "s/replace_with_ip/$NFS_SRV_IP/"  ./menu.ipxe
 
 wget https://cloud.3mdeb.com/index.php/s/pHIz1Ir9m68Bjq3/download -O kernels.tar.gz
 
 tar -xzvf kernels.tar.gz && rm kernels.tar.gz
 
 cd ..
-wget https://cloud.3mdeb.com/index.php/s/7m5dDKW8eGG4AoJ/download -O debian-stretch.tar.gz
+wget https://cloud.3mdeb.com/index.php/s/J4fD8wLcK5phIm3/download -O debian-stable.tar.gz
 
 mkdir debian
-tar -xvpzf debian-stretch.tar.gz -C ./debian --numeric-owner 
+tar -xvpzf debian-stable.tar.gz -C ./debian --numeric-owner
 
 mkdir voyage
 wget https://cloud.3mdeb.com/index.php/s/rUZPwRHOjxpSxN4/download -O voyage-0.11.0_amd64.tar.gz
 
 tar -xzvf voyage-0.11.0_amd64.tar.gz -C ./voyage
 rm voyage-0.11.0_amd64.tar.gz 
-rm debian-stretch.tar.gz
+rm debian-stable.tar.gz

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,7 @@
 set -e
 
 export_base="/srv/nfs/"
+HTTP_SRV="/srv/http/"
 
 ### Handle `docker stop` for graceful shutdown
 function shutdown {
@@ -41,7 +42,5 @@ exportfs -ra
 service nfs-kernel-server start
 
 echo "- Nfs server is up and running.."
-# configure tftp
-sed -i 's/TFTP_DIRECTORY=\"\/var\/lib\/tftpboot\"/TFTP_DIRECTORY=\"\/srv\/tftp\"/' /etc/default/tftpd-hpa
-sed -i 's/secure/secure -c/' /etc/default/tftpd-hpa
-/etc/init.d/tftpd-hpa start
+cd $HTTP_SRV
+python -m SimpleHTTPServer 8000

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ fi
 
 
 docker run --rm --name pxeserver --privileged \
-	 -p 111:111/tcp -p 69:69/udp -p 2049:2049/tcp \
+	 -p 111:111/tcp -p 2049:2049/tcp \
 	 -p 627:627/tcp -p 627:627/udp -p 875:875/tcp -p 875:875/udp \
 	 -p 892:892/tcp -p 892:892/udp -p 111:111/udp -p 2049:2049/udp \
 	 -p 10053:10053/udp -p 10053:10053/tcp \
@@ -19,10 +19,10 @@ docker run --rm --name pxeserver --privileged \
 	 -p 32765:32765/tcp -p 32765:32765/udp \
 	 -p 32766:32766/tcp -p 32766:32766/udp \
 	 -p 32767:32767/tcp -p 32767:32767/udp \
-	 -v ${PWD}/netboot:/srv/tftp \
+	 -v ${PWD}/netboot:/srv/http \
 	 -v ${PWD}/debian:/srv/nfs/debian \
 	 -v ${PWD}/voyage:/srv/nfs/voyage \
 	 -t -i 3mdeb/pxe-server /bin/bash -c \
-	 "bash /usr/local/bin/run.sh;/bin/bash" $@
+	 "bash /usr/local/bin/run.sh"
 
 

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ fi
 
 
 docker run --rm --name pxeserver --privileged \
-	 -p 111:111/tcp -p 2049:2049/tcp \
+	 -p 111:111/tcp -p 2049:2049/tcp -p 8000:8000/tcp \
 	 -p 627:627/tcp -p 627:627/udp -p 875:875/tcp -p 875:875/udp \
 	 -p 892:892/tcp -p 892:892/udp -p 111:111/udp -p 2049:2049/udp \
 	 -p 10053:10053/udp -p 10053:10053/tcp \


### PR DESCRIPTION
TFTP have problems in various netowrok configurations. I consider it not exactly reliable HTTP is much modern approach and it works.

TODO:
* netinst - I don't like current implementation because it download whole netboot package from repository, what takes time - we should rather utilize what is exposed on servers. Maybe just pull kernel and initrd.
* we should also support various install methods: debian stable, testing and uefi-aware flavours

I pushed recent debian-stable to our cloud server - this install is much cleaner. What can be improved is adding to `/etc/issue` information about logging in to system.